### PR TITLE
Add GitHub issue templates and TMOS compatibility note

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a bug with the CGNAT PBA monitoring tools
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+**Component**
+Which tool is affected?
+- [ ] cgnat_pba_stats.py (remote SSH query)
+- [ ] cgnat_pba_stats_bigip_compatible.py (local BIG-IP query)
+- [ ] cgnat_pba_collect.py (data collector)
+- [ ] install-pba-stats.sh (installer)
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Run command '...'
+2. With arguments '...'
+3. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened. Include error messages or output if applicable.
+
+**Environment**
+- BIG-IP version: [e.g. 17.1.1]
+- TMOS shell: [e.g. bash, tmsh]
+- Python version: [e.g. 2.7, 3.9]
+- Output destination (for cgnat_pba_collect): [e.g. CSV, MySQL]
+
+**Additional context**
+Any other context, logs, or screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+**Component**
+Which tool does this relate to?
+- [ ] cgnat_pba_stats.py (remote SSH query)
+- [ ] cgnat_pba_stats_bigip_compatible.py (local BIG-IP query)
+- [ ] cgnat_pba_collect.py (data collector)
+- [ ] install-pba-stats.sh (installer)
+- [ ] New tool / other
+
+**Problem or use case**
+Describe the problem you're trying to solve or the use case this would address.
+
+**Proposed solution**
+How you'd like this to work.
+
+**Alternatives considered**
+Any alternative solutions or workarounds you've considered.
+
+**Additional context**
+Any other context, examples, or references.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Bash installer that deploys `cgnat_pba_stats_bigip_compatible.py` to a BIG-IP. V
 ./python/install-pba-stats.sh <bigip_host> [--user USERNAME] [--password] [--port PORT]
 ```
 
+## Compatibility
+
+These tools were developed and tested against **TMOS 17.1**. Older TMOS versions may not be supported, as differences in `lsndb` or `tmsh` command output formats could cause parsing failures.
+
 ## Background
 
 F5 BIG-IP CGNAT uses PBA to allocate port blocks to subscribers. BIG-IP does not provide a single CLI command to view per-subscriber port block allocations in a consolidated format. These tools bridge that gap by querying `lsndb` (for live PBA/inbound state) and `tmsh` (for pool configuration), then presenting the data in a readable format.


### PR DESCRIPTION
## Summary
- Add bug report and feature request issue templates with component selectors for each tool
- Add compatibility section to README noting tools were developed and tested against TMOS 17.1

## Test plan
- [ ] Verify issue templates appear when creating a new issue on GitHub
- [ ] Confirm README renders correctly with the new compatibility section

🤖 Generated with [Claude Code](https://claude.com/claude-code)