### PR TITLE
Fix PBA regex for optional (N/A) field in lsndb output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Bash installer that deploys `cgnat_pba_stats_bigip_compatible.py` to a BIG-IP. V
 
 ## Compatibility
 
-These tools were developed and tested against **TMOS 17.1**. Older TMOS versions may not be supported, as differences in `lsndb` or `tmsh` command output formats could cause parsing failures.
+These tools were developed and tested against **TMOS 17.1** and **17.5.1.3 (build 0.0.19)**. Older TMOS versions may not be supported, as differences in `lsndb` or `tmsh` command output formats could cause parsing failures.
 
 ## Background
 

--- a/python/cgnat_pba_collect.py
+++ b/python/cgnat_pba_collect.py
@@ -118,6 +118,7 @@ def get_pba_entries() -> list[dict]:
         m = re.match(
             r"(\d+\.\d+\.\d+\.\d+)\s+"
             r"(\d+\.\d+\.\d+\.\d+):(\d+)\s+-\s+(\d+)\s+"
+            r"(?:\(\S+\)\s+)?"
             r"(\S+)\s+"
             r"(\d+)",
             line,

--- a/python/cgnat_pba_stats.py
+++ b/python/cgnat_pba_stats.py
@@ -91,6 +91,7 @@ def get_pba_entries() -> list[dict]:
         m = re.match(
             r"(\d+\.\d+\.\d+\.\d+)\s+"
             r"(\d+\.\d+\.\d+\.\d+):(\d+)\s+-\s+(\d+)\s+"
+            r"(?:\(\S+\)\s+)?"
             r"(\S+)\s+"
             r"(\d+)",
             line,

--- a/python/cgnat_pba_stats_bigip_compatible.py
+++ b/python/cgnat_pba_stats_bigip_compatible.py
@@ -73,6 +73,7 @@ def get_pba_entries():
         m = re.match(
             r"(\d+\.\d+\.\d+\.\d+)\s+"
             r"(\d+\.\d+\.\d+\.\d+):(\d+)\s+-\s+(\d+)\s+"
+            r"(?:\(\S+\)\s+)?"
             r"(\S+)\s+"
             r"(\d+)",
             line,


### PR DESCRIPTION
## Summary
- Fix `get_pba_entries()` regex in all three scripts to handle an optional parenthesized field (e.g. `(N/A)`) between port range and subscriber ID in `lsndb list pba` output
- Update README compatibility section to include TMOS 17.5.1.3 (build 0.0.19)

Closes #4

## Test plan
- [x] Regex verified locally against both output formats (with and without `(N/A)`)
- [x] `cgnat_pba_stats_bigip_compatible.py` tested on BIG-IP 17.5.1.3 — all 10 PBA entries parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)