### PR TITLE
Fix PATH escaping in install-pba-stats.sh

### DIFF
--- a/python/install-pba-stats.sh
+++ b/python/install-pba-stats.sh
@@ -135,7 +135,7 @@ run_ssh "chmod +x $REMOTE_PATH"
 
 echo "==> Configuring PATH ..."
 PROFILE="/etc/profile.d/pba-stats.sh"
-PATH_LINE="export PATH=$PATH_DIR:\\\$PATH"
+PATH_LINE="export PATH=$PATH_DIR:\$PATH"
 run_ssh "echo '$PATH_LINE' > $PROFILE"
 echo "    Created $PROFILE"
 


### PR DESCRIPTION
## Summary
- Fix triple-escaped `\\\$PATH` that produced a literal `\$PATH` in `/etc/profile.d/pba-stats.sh`
- Reduced to single escape so the profile correctly writes `export PATH=/shared/scripts:$PATH`

Closes #6

## Test plan
- [x] Ran installer against BIG-IP 17.5.1.3
- [x] Verified `/etc/profile.d/pba-stats.sh` contains `export PATH=/shared/scripts:$PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)