### PR TITLE
Validate --db-table to prevent SQL injection

### DIFF
--- a/python/cgnat_pba_collect.py
+++ b/python/cgnat_pba_collect.py
@@ -309,6 +309,9 @@ def export_mysql(rows: list[dict], timestamp: str, device: str,
                  db_host: str, db_port: int, db_name: str,
                  db_user: str, db_pass: str, db_table: str):
     """Write aggregated data to MySQL."""
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", db_table):
+        print(f"ERROR: Invalid table name: {db_table}", file=sys.stderr)
+        sys.exit(1)
     try:
         import mysql.connector
     except ImportError:


### PR DESCRIPTION
## Summary
- Add regex validation for `--db-table` parameter in `cgnat_pba_collect.py` to prevent SQL injection
- Table name must match `^[a-zA-Z_][a-zA-Z0-9_]*$`

Closes #8

## Test plan
- [x] Validated regex blocks injection attempts (`; DROP TABLE`, spaces, hyphens)
- [x] Validated regex allows legitimate names (`pba_stats`, `_private`, `Table1`)
- [x] Script imports and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)