### PR TITLE
Require explicit opt-in to skip SSH host key verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See [python/README.md](python/README.md) for detailed usage.
 Bash installer that deploys `cgnat_pba_stats_bigip_compatible.py` to a BIG-IP. Validates the target is a BIG-IP before installing, copies the script to persistent storage, adds it to PATH, and configures boot persistence.
 
 ```bash
-./python/install-pba-stats.sh <bigip_host> [--user USERNAME] [--password] [--port PORT]
+./python/install-pba-stats.sh <bigip_host> [--user USERNAME] [--password] [--port PORT] [--insecure]
 ```
 
 ## Compatibility
@@ -37,3 +37,9 @@ F5 BIG-IP CGNAT uses PBA to allocate port blocks to subscribers. BIG-IP does not
 | `lsndb list pba` | Port block allocations (client IP, external IP, port range, TTL) |
 | `lsndb list inbound` | Active inbound mappings (used to count ports in use per block) |
 | `tmsh list security nat source-translation one-line` | Pool configuration (block size, client block limit, address ranges) |
+
+## Author & Support
+
+Developed by Greg "G-Rob" Robinson from F5.
+
+This is a community project and is **not supported by F5 Support**. For bugs, feature requests, or questions, please open a [GitHub issue](https://github.com/SalesAmerSP/f5_bigip_cgnat_pba_stats/issues).

--- a/python/README.md
+++ b/python/README.md
@@ -14,6 +14,7 @@ python cgnat_pba_stats.py --bigip 10.0.0.1 --all
 python cgnat_pba_stats.py --bigip 10.0.0.1 --summary
 python cgnat_pba_stats.py --bigip 10.0.0.1 --user admin --all   # prompts for password
 python cgnat_pba_stats.py --bigip 10.0.0.1 --port 47001 --all   # custom SSH port
+python cgnat_pba_stats.py --bigip 10.0.0.1 --all --no-host-key-check  # skip host key verification
 ```
 
 ### cgnat_pba_stats_bigip_compatible.py
@@ -32,12 +33,13 @@ pba-stats --summary
 Use the installer script:
 
 ```bash
-./install-pba-stats.sh <bigip_host> [--user USERNAME] [--password] [--port PORT]
+./install-pba-stats.sh <bigip_host> [--user USERNAME] [--password] [--port PORT] [--insecure]
 
 # Examples
 ./install-pba-stats.sh 10.0.0.1 --password                              # admin user, prompts for password
 ./install-pba-stats.sh 10.0.0.1                                         # admin user, SSH key auth
 ./install-pba-stats.sh 10.0.0.1 --user root --port 47001 --password     # custom user/port + password
+./install-pba-stats.sh 10.0.0.1 --insecure                              # skip host key verification
 ```
 
 The username defaults to `admin`. When `--password` is specified, SSH prompts for the password (once per command). Without `--password`, SSH key-based authentication is used. The installer tries SCP first and falls back to base64 transfer over SSH if SCP is unavailable.
@@ -80,6 +82,9 @@ python cgnat_pba_collect.py --bigip 10.0.0.1 --output mysql \
 
 # With SSH credentials
 python cgnat_pba_collect.py --bigip 10.0.0.1 --user admin --output csv
+
+# Skip host key verification
+python cgnat_pba_collect.py --bigip 10.0.0.1 --output csv --no-host-key-check
 ```
 
 Per-subscriber aggregated fields: pool, client_ip, ports in use, block count, external IPs, block_size, client_block_limit.

--- a/python/cgnat_pba_collect.py
+++ b/python/cgnat_pba_collect.py
@@ -50,11 +50,15 @@ CSV_FILE = None  # None = stdout
 # ---------------------------------------------------------------------------
 
 def ssh_connect(host: str, port: int, username: str | None = None,
-                password: str | None = None):
+                password: str | None = None, no_host_key_check: bool = False):
     """Establish a persistent SSH connection to the BIG-IP."""
     global SSH_CLIENT
     SSH_CLIENT = paramiko.SSHClient()
-    SSH_CLIENT.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    if no_host_key_check:
+        SSH_CLIENT.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    else:
+        SSH_CLIENT.load_system_host_keys()
+        SSH_CLIENT.set_missing_host_key_policy(paramiko.WarningPolicy())
     SSH_CLIENT.connect(
         hostname=host,
         port=port,
@@ -372,6 +376,8 @@ def main():
     parser.add_argument("--db-user", default=DB_USER, help=f"MySQL user (default: {DB_USER})")
     parser.add_argument("--db-pass", default=DB_PASS, help="MySQL password")
     parser.add_argument("--db-table", default=DB_TABLE, help=f"MySQL table (default: {DB_TABLE})")
+    parser.add_argument("--no-host-key-check", action="store_true",
+                        help="Disable SSH host key verification (insecure)")
 
     args = parser.parse_args()
 
@@ -381,7 +387,8 @@ def main():
         password = getpass.getpass(f"Password for {username}@{args.bigip}: ")
 
     try:
-        ssh_connect(args.bigip, int(args.port), username=username, password=password)
+        ssh_connect(args.bigip, int(args.port), username=username, password=password,
+                    no_host_key_check=args.no_host_key_check)
     except Exception as e:
         print(f"ERROR: Cannot connect to {args.bigip}:{args.port} - {e}", file=sys.stderr)
         sys.exit(1)

--- a/python/cgnat_pba_stats.py
+++ b/python/cgnat_pba_stats.py
@@ -25,11 +25,15 @@ SSH_CLIENT: paramiko.SSHClient | None = None
 
 
 def ssh_connect(host: str, port: int, username: str | None = None,
-                password: str | None = None):
+                password: str | None = None, no_host_key_check: bool = False):
     """Establish a persistent SSH connection to the BIG-IP."""
     global SSH_CLIENT
     SSH_CLIENT = paramiko.SSHClient()
-    SSH_CLIENT.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    if no_host_key_check:
+        SSH_CLIENT.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    else:
+        SSH_CLIENT.load_system_host_keys()
+        SSH_CLIENT.set_missing_host_key_policy(paramiko.WarningPolicy())
     SSH_CLIENT.connect(
         hostname=host,
         port=port,
@@ -755,6 +759,8 @@ def main():
                         help="Show enhanced stats (utilization %%, protocol breakdown, top subscribers, etc.)")
     parser.add_argument("--json", action="store_true",
                         help="Output data as JSON instead of text")
+    parser.add_argument("--no-host-key-check", action="store_true",
+                        help="Disable SSH host key verification (insecure)")
 
     args = parser.parse_args()
 
@@ -764,7 +770,8 @@ def main():
         password = getpass.getpass(f"Password for {username}@{args.bigip}: ")
 
     try:
-        ssh_connect(args.bigip, int(args.port), username=username, password=password)
+        ssh_connect(args.bigip, int(args.port), username=username, password=password,
+                    no_host_key_check=args.no_host_key_check)
     except Exception as e:
         print(f"ERROR: Cannot connect to {args.bigip}:{args.port} - {e}", file=sys.stderr)
         sys.exit(1)

--- a/python/install-pba-stats.sh
+++ b/python/install-pba-stats.sh
@@ -3,12 +3,13 @@
 # Install pba-stats on a F5 BIG-IP
 #
 # Usage:
-#   ./install-pba-stats.sh <bigip_host> [--user USERNAME] [--password] [--port PORT]
+#   ./install-pba-stats.sh <bigip_host> [--user USERNAME] [--password] [--port PORT] [--insecure]
 #
 # Examples:
 #   ./install-pba-stats.sh 10.0.0.1 --password                # admin user, prompts for password
 #   ./install-pba-stats.sh 10.0.0.1                           # admin user, SSH key auth
 #   ./install-pba-stats.sh 10.0.0.1 --user root --port 47001 --password
+#   ./install-pba-stats.sh 10.0.0.1 --insecure                # skip host key verification
 
 set -euo pipefail
 
@@ -24,6 +25,7 @@ usage() {
     echo "  --user USERNAME   SSH username (default: admin)"
     echo "  --password        Prompt for SSH password (otherwise uses key auth)"
     echo "  --port PORT       SSH port (default: 22)"
+    echo "  --insecure        Skip SSH host key verification"
     exit 1
 }
 
@@ -37,6 +39,7 @@ shift
 SSH_USER="admin"
 SSH_PORT="22"
 USE_PASSWORD=false
+INSECURE=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -52,6 +55,10 @@ while [ $# -gt 0 ]; do
             SSH_PORT="$2"
             shift 2
             ;;
+        --insecure)
+            INSECURE=true
+            shift
+            ;;
         *)
             echo "ERROR: Unknown option: $1"
             usage
@@ -59,7 +66,10 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
+SSH_OPTS="-o ConnectTimeout=10"
+if [ "$INSECURE" = true ]; then
+    SSH_OPTS="$SSH_OPTS -o StrictHostKeyChecking=no"
+fi
 
 if [ -n "$SSH_USER" ]; then
     SSH_TARGET="$SSH_USER@$BIGIP_HOST"


### PR DESCRIPTION
## Summary
- Default to `WarningPolicy` with system host keys in both Python scripts
- Add `--no-host-key-check` flag to explicitly opt into `AutoAddPolicy`
- Remove default `StrictHostKeyChecking=no` in installer; add `--insecure` flag
- Update both READMEs with new flag documentation
- Add Author & Support section to main README

Closes #9

## Test plan
- [x] Tested `cgnat_pba_stats.py --no-host-key-check` against BIG-IP 17.5.1.3
- [x] Tested `install-pba-stats.sh --insecure` against BIG-IP 17.5.1.3
- [x] Verified installed script runs correctly on BIG-IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)