### PR TITLE
Add .gitignore entries for secrets and sensitive output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,14 @@ Temporary Items
 # Built Visual Studio Code Extensions
 *.vsix
 
+# Secrets and credentials
+.env
+*.pem
+*.key
+id_rsa*
+
+# Output files (may contain subscriber data)
+*.csv
+
 # Claude Code
 .claude/


### PR DESCRIPTION
## Summary
- Exclude `.env`, SSH keys (`*.pem`, `*.key`, `id_rsa*`), and `*.csv` output files
- Prevents accidental commits of credentials or subscriber data

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)