### PR TITLE
Fix port over-counting when port used for both TCP and UDP

### DIFF
--- a/python/cgnat_pba_stats.py
+++ b/python/cgnat_pba_stats.py
@@ -184,12 +184,15 @@ def find_pool_for_ip(external_ip: str, pools: dict) -> tuple[str, dict]:
 
 
 def count_ports_used(client_ip: str, port_start: int, port_end: int, mappings: list[dict]) -> int:
-    """Count how many inbound mapping ports fall within a port block for a client."""
-    count = 0
+    """Count unique ports used within a port block for a client.
+
+    A port used by both TCP and UDP is counted once (unique port count).
+    """
+    ports = set()
     for m in mappings:
         if m["client_ip"] == client_ip and port_start <= m["translation_port"] <= port_end:
-            count += 1
-    return count
+            ports.add(m["translation_port"])
+    return len(ports)
 
 
 def count_ports_by_protocol(client_ip: str, port_start: int, port_end: int,

--- a/python/cgnat_pba_stats_bigip_compatible.py
+++ b/python/cgnat_pba_stats_bigip_compatible.py
@@ -144,11 +144,11 @@ def find_pool_for_ip(external_ip, pools):
 
 
 def count_ports_used(client_ip, port_start, port_end, mappings):
-    count = 0
+    ports = set()
     for m in mappings:
         if m["client_ip"] == client_ip and port_start <= m["translation_port"] <= port_end:
-            count += 1
-    return count
+            ports.add(m["translation_port"])
+    return len(ports)
 
 
 def count_ports_by_protocol(client_ip, port_start, port_end, mappings):


### PR DESCRIPTION
## Summary
- Change `count_ports_used` to count unique port numbers (using a set) instead of total inbound mappings
- When a port is used for both TCP and UDP, `lsndb list inbound` shows two entries, previously inflating the count beyond block size
- The collector already used sets and was not affected

Closes #21

## Test plan
- [x] Tested on BIG-IP 17.5.1.3 — all port counts now within block size
- [x] Previously showed counts like 601/512; now correctly counts unique ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)