### PR TITLE
Fix SSH reconnection, remove hardcoded pool defaults, improve installer

### DIFF
--- a/python/cgnat_pba_collect.py
+++ b/python/cgnat_pba_collect.py
@@ -31,6 +31,7 @@ import paramiko
 
 DEVICE_NAME = "bigip01"
 SSH_CLIENT: paramiko.SSHClient | None = None
+SSH_CONNECT_PARAMS: dict | None = None
 
 OUTPUT_MODE = "csv"  # "csv" or "mysql"
 
@@ -52,28 +53,64 @@ CSV_FILE = None  # None = stdout
 def ssh_connect(host: str, port: int, username: str | None = None,
                 password: str | None = None, no_host_key_check: bool = False):
     """Establish a persistent SSH connection to the BIG-IP."""
+    global SSH_CONNECT_PARAMS
+    SSH_CONNECT_PARAMS = {
+        "hostname": host, "port": port, "username": username,
+        "password": password, "timeout": 10,
+        "allow_agent": password is None, "look_for_keys": password is None,
+        "no_host_key_check": no_host_key_check,
+    }
+    _do_ssh_connect()
+
+
+def _do_ssh_connect():
+    """Internal: create and connect SSH client using stored params."""
     global SSH_CLIENT
+    params = SSH_CONNECT_PARAMS
     SSH_CLIENT = paramiko.SSHClient()
-    if no_host_key_check:
+    if params["no_host_key_check"]:
         SSH_CLIENT.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     else:
         SSH_CLIENT.load_system_host_keys()
         SSH_CLIENT.set_missing_host_key_policy(paramiko.WarningPolicy())
     SSH_CLIENT.connect(
-        hostname=host,
-        port=port,
-        username=username,
-        password=password,
-        timeout=10,
-        allow_agent=password is None,
-        look_for_keys=password is None,
+        hostname=params["hostname"], port=params["port"],
+        username=params["username"], password=params["password"],
+        timeout=params["timeout"],
+        allow_agent=params["allow_agent"],
+        look_for_keys=params["look_for_keys"],
     )
 
 
 def ssh_command(cmd: str, timeout: int = 30) -> str:
-    """Execute a command on the BIG-IP via the persistent SSH connection."""
+    """Execute a command on the BIG-IP via SSH, reconnecting if needed.
+
+    BIG-IP only supports one channel per SSH connection, so each command
+    after the first requires a fresh connection. A brief delay avoids
+    connection rate-limiting on the BIG-IP side.
+    """
+    import time
+    global SSH_CLIENT
     assert SSH_CLIENT is not None, "SSH connection not established"
-    _stdin, stdout, stderr = SSH_CLIENT.exec_command(cmd, timeout=timeout)
+    try:
+        _, stdout, stderr = SSH_CLIENT.exec_command(cmd, timeout=timeout)
+    except paramiko.SSHException:
+        try:
+            SSH_CLIENT.close()
+        except Exception:
+            pass
+        last_err = None
+        for attempt in range(3):
+            try:
+                time.sleep(1 + attempt)
+                _do_ssh_connect()
+                _, stdout, stderr = SSH_CLIENT.exec_command(cmd, timeout=timeout)
+                last_err = None
+                break
+            except Exception as e:
+                last_err = e
+        if last_err is not None:
+            raise last_err
     output = stdout.read().decode() or stderr.read().decode() or ""
     lines = output.strip().split("\n")
     if len(lines) > 2:
@@ -100,8 +137,11 @@ def get_pool_configs() -> dict:
         bs_match = re.search(r"block-size (\d+)", line)
         cbl_match = re.search(r"client-block-limit (\d+)", line)
         addr_match = re.findall(r"addresses \{([^}]+)\}", line)
-        block_size = int(bs_match.group(1)) if bs_match else 256
-        client_block_limit = int(cbl_match.group(1)) if cbl_match else 1
+        if not bs_match or not cbl_match:
+            print(f"WARNING: Could not parse block-size/client-block-limit for {name}", file=sys.stderr)
+            continue
+        block_size = int(bs_match.group(1))
+        client_block_limit = int(cbl_match.group(1))
         addresses = []
         if addr_match:
             addresses = [a.strip().rstrip(" { }") for a in addr_match[0].split("}") if a.strip()]

--- a/python/cgnat_pba_stats.py
+++ b/python/cgnat_pba_stats.py
@@ -22,33 +22,70 @@ import paramiko
 
 
 SSH_CLIENT: paramiko.SSHClient | None = None
+SSH_CONNECT_PARAMS: dict | None = None
 
 
 def ssh_connect(host: str, port: int, username: str | None = None,
                 password: str | None = None, no_host_key_check: bool = False):
     """Establish a persistent SSH connection to the BIG-IP."""
+    global SSH_CLIENT, SSH_CONNECT_PARAMS
+    SSH_CONNECT_PARAMS = {
+        "hostname": host, "port": port, "username": username,
+        "password": password, "timeout": 10,
+        "allow_agent": password is None, "look_for_keys": password is None,
+        "no_host_key_check": no_host_key_check,
+    }
+    _do_ssh_connect()
+
+
+def _do_ssh_connect():
+    """Internal: create and connect SSH client using stored params."""
     global SSH_CLIENT
+    params = SSH_CONNECT_PARAMS
     SSH_CLIENT = paramiko.SSHClient()
-    if no_host_key_check:
+    if params["no_host_key_check"]:
         SSH_CLIENT.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     else:
         SSH_CLIENT.load_system_host_keys()
         SSH_CLIENT.set_missing_host_key_policy(paramiko.WarningPolicy())
     SSH_CLIENT.connect(
-        hostname=host,
-        port=port,
-        username=username,
-        password=password,
-        timeout=10,
-        allow_agent=password is None,
-        look_for_keys=password is None,
+        hostname=params["hostname"], port=params["port"],
+        username=params["username"], password=params["password"],
+        timeout=params["timeout"],
+        allow_agent=params["allow_agent"],
+        look_for_keys=params["look_for_keys"],
     )
 
 
 def ssh_command(cmd: str, timeout: int = 30) -> str:
-    """Execute a command on the BIG-IP via the persistent SSH connection."""
+    """Execute a command on the BIG-IP via SSH, reconnecting if needed.
+
+    BIG-IP only supports one channel per SSH connection, so each command
+    after the first requires a fresh connection. A brief delay and retry
+    avoids connection rate-limiting on the BIG-IP side.
+    """
+    import time
+    global SSH_CLIENT
     assert SSH_CLIENT is not None, "SSH connection not established"
-    _stdin, stdout, stderr = SSH_CLIENT.exec_command(cmd, timeout=timeout)
+    try:
+        _, stdout, stderr = SSH_CLIENT.exec_command(cmd, timeout=timeout)
+    except paramiko.SSHException:
+        try:
+            SSH_CLIENT.close()
+        except Exception:
+            pass
+        last_err = None
+        for attempt in range(3):
+            try:
+                time.sleep(1 + attempt)
+                _do_ssh_connect()
+                _, stdout, stderr = SSH_CLIENT.exec_command(cmd, timeout=timeout)
+                last_err = None
+                break
+            except Exception as e:
+                last_err = e
+        if last_err is not None:
+            raise last_err
     output = stdout.read().decode() or stderr.read().decode() or ""
     lines = output.strip().split("\n")
     if len(lines) > 2:
@@ -72,8 +109,11 @@ def get_pool_configs() -> dict:
         bs_match = re.search(r"block-size (\d+)", line)
         cbl_match = re.search(r"client-block-limit (\d+)", line)
         addr_match = re.findall(r"addresses \{([^}]+)\}", line)
-        block_size = int(bs_match.group(1)) if bs_match else 256
-        client_block_limit = int(cbl_match.group(1)) if cbl_match else 1
+        if not bs_match or not cbl_match:
+            print(f"WARNING: Could not parse block-size/client-block-limit for {name}", file=sys.stderr)
+            continue
+        block_size = int(bs_match.group(1))
+        client_block_limit = int(cbl_match.group(1))
         addresses = []
         if addr_match:
             addresses = [a.strip().rstrip(" { }") for a in addr_match[0].split("}") if a.strip()]
@@ -181,6 +221,19 @@ def find_pool_for_ip(external_ip: str, pools: dict) -> tuple[str, dict]:
             except ValueError:
                 continue
     return None, None
+
+
+def infer_block_size(entries: list[dict]) -> int:
+    """Infer block size from PBA entries' port ranges when pool config is unavailable."""
+    if entries:
+        e = entries[0]
+        return e["port_end"] - e["port_start"] + 1
+    return 0
+
+
+def unknown_pool_cfg(entries: list[dict]) -> dict:
+    """Build a placeholder pool config for entries that don't match any known pool."""
+    return {"block_size": infer_block_size(entries), "client_block_limit": 0, "addresses": []}
 
 
 def count_ports_used(client_ip: str, port_start: int, port_end: int, mappings: list[dict]) -> int:
@@ -416,7 +469,7 @@ def show_host(host_ip: str, pba_entries: list[dict], mappings: list[dict], pools
 
     pool_name, pool_cfg = find_pool_for_ip(host_entries[0]["external_ip"], pools)
     if not pool_cfg:
-        pool_cfg = {"block_size": 256, "client_block_limit": 1, "addresses": []}
+        pool_cfg = unknown_pool_cfg(host_entries)
         pool_name = "Unknown"
 
     total_blocks = calc_total_port_blocks(pool_cfg)
@@ -463,8 +516,8 @@ def show_all(pba_entries: list[dict], mappings: list[dict], pools: dict,
         if not first:
             print()
         first = False
-        pool_cfg = pools.get(pool_name, {"block_size": 256, "client_block_limit": 1, "addresses": []})
         entries = pool_groups[pool_name]
+        pool_cfg = pools.get(pool_name) or unknown_pool_cfg(entries)
         total_blocks = calc_total_port_blocks(pool_cfg)
         print_pool_header(pool_name, pool_cfg, len(entries), total_blocks, enhanced=enhanced)
         print_pba_rows(entries, mappings, pool_cfg["block_size"], enhanced=enhanced)
@@ -615,7 +668,7 @@ def json_host(host_ip: str, pba_entries: list[dict], mappings: list[dict], pools
 
     pool_name, pool_cfg = find_pool_for_ip(host_entries[0]["external_ip"], pools)
     if not pool_cfg:
-        pool_cfg = {"block_size": 256, "client_block_limit": 1, "addresses": []}
+        pool_cfg = unknown_pool_cfg(host_entries)
         pool_name = "Unknown"
 
     block_size = pool_cfg["block_size"]
@@ -674,7 +727,7 @@ def json_xlated_ip(xlated_ip: str, pba_entries: list[dict], mappings: list[dict]
 
     pool_name, pool_cfg = find_pool_for_ip(xlated_ip, pools)
     if not pool_cfg:
-        pool_cfg = {"block_size": 256, "client_block_limit": 1, "addresses": []}
+        pool_cfg = unknown_pool_cfg(filtered)
         pool_name = "Unknown"
 
     total_blocks = calc_total_port_blocks(pool_cfg)
@@ -693,9 +746,10 @@ def json_all(pba_entries: list[dict], mappings: list[dict], pools: dict) -> dict
 
     pool_data = []
     for pool_name in sorted(pool_groups.keys()):
-        pool_cfg = pools.get(pool_name, {"block_size": 256, "client_block_limit": 1, "addresses": []})
+        entries = pool_groups[pool_name]
+        pool_cfg = pools.get(pool_name) or unknown_pool_cfg(entries)
         total_blocks = calc_total_port_blocks(pool_cfg)
-        pool_data.append(build_pool_data(pool_name, pool_cfg, pool_groups[pool_name], mappings, total_blocks))
+        pool_data.append(build_pool_data(pool_name, pool_cfg, entries, mappings, total_blocks))
 
     return {
         "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -828,7 +882,7 @@ def main():
             else:
                 pool_name, pool_cfg = find_pool_for_ip(args.xlated_ip, pools)
                 if not pool_cfg:
-                    pool_cfg = {"block_size": 256, "client_block_limit": 1, "addresses": []}
+                    pool_cfg = unknown_pool_cfg(filtered)
                     pool_name = "Unknown"
                 total_blocks = calc_total_port_blocks(pool_cfg)
                 print_pool_header(pool_name, pool_cfg, len(filtered), total_blocks,

--- a/python/cgnat_pba_stats_bigip_compatible.py
+++ b/python/cgnat_pba_stats_bigip_compatible.py
@@ -52,8 +52,11 @@ def get_pool_configs():
         bs_match = re.search(r"block-size (\d+)", line)
         cbl_match = re.search(r"client-block-limit (\d+)", line)
         addr_match = re.findall(r"addresses \{([^}]+)\}", line)
-        block_size = int(bs_match.group(1)) if bs_match else 256
-        client_block_limit = int(cbl_match.group(1)) if cbl_match else 1
+        if not bs_match or not cbl_match:
+            print("WARNING: Could not parse block-size/client-block-limit for %s" % name, file=sys.stderr)
+            continue
+        block_size = int(bs_match.group(1))
+        client_block_limit = int(cbl_match.group(1))
         addresses = []
         if addr_match:
             addresses = [a.strip().rstrip(" { }") for a in addr_match[0].split("}") if a.strip()]
@@ -118,6 +121,19 @@ def get_inbound_mappings():
 # ---------------------------------------------------------------------------
 # Pool / IP helpers
 # ---------------------------------------------------------------------------
+
+def infer_block_size(entries):
+    """Infer block size from PBA entries' port ranges when pool config is unavailable."""
+    if entries:
+        e = entries[0]
+        return e["port_end"] - e["port_start"] + 1
+    return 0
+
+
+def unknown_pool_cfg(entries):
+    """Build a placeholder pool config for entries that don't match any known pool."""
+    return {"block_size": infer_block_size(entries), "client_block_limit": 0, "addresses": []}
+
 
 def find_pool_for_ip(external_ip, pools):
     ext = ipaddress.ip_address(external_ip)
@@ -184,7 +200,10 @@ def calc_total_port_blocks(pool_cfg):
         except ValueError:
             continue
     port_range = 65535 - 1024 + 1
-    blocks_per_ip = port_range // pool_cfg.get("block_size", 256)
+    block_size = pool_cfg.get("block_size", 0)
+    if block_size == 0:
+        return 0
+    blocks_per_ip = port_range // block_size
     return total_ips * blocks_per_ip
 
 
@@ -347,7 +366,7 @@ def show_host(host_ip, pba_entries, mappings, pools, enhanced=False):
         return
     pool_name, pool_cfg = find_pool_for_ip(host_entries[0]["external_ip"], pools)
     if not pool_cfg:
-        pool_cfg = {"block_size": 256, "client_block_limit": 1, "addresses": []}
+        pool_cfg = unknown_pool_cfg(host_entries)
         pool_name = "Unknown"
     total_blocks = calc_total_port_blocks(pool_cfg)
     print_pool_header(pool_name, pool_cfg, len(host_entries), total_blocks, per_host=True,
@@ -389,8 +408,8 @@ def show_all(pba_entries, mappings, pools, enhanced=False):
         if not first:
             print()
         first = False
-        pool_cfg = pools.get(pool_name, {"block_size": 256, "client_block_limit": 1, "addresses": []})
         entries = pool_groups[pool_name]
+        pool_cfg = pools.get(pool_name) or unknown_pool_cfg(entries)
         total_blocks = calc_total_port_blocks(pool_cfg)
         print_pool_header(pool_name, pool_cfg, len(entries), total_blocks, enhanced=enhanced)
         print_pba_rows(entries, mappings, pool_cfg["block_size"], enhanced=enhanced)
@@ -523,7 +542,7 @@ def json_host(host_ip, pba_entries, mappings, pools):
 
     pool_name, pool_cfg = find_pool_for_ip(host_entries[0]["external_ip"], pools)
     if not pool_cfg:
-        pool_cfg = {"block_size": 256, "client_block_limit": 1, "addresses": []}
+        pool_cfg = unknown_pool_cfg(host_entries)
         pool_name = "Unknown"
 
     block_size = pool_cfg["block_size"]
@@ -582,7 +601,7 @@ def json_xlated_ip(xlated_ip, pba_entries, mappings, pools):
 
     pool_name, pool_cfg = find_pool_for_ip(xlated_ip, pools)
     if not pool_cfg:
-        pool_cfg = {"block_size": 256, "client_block_limit": 1, "addresses": []}
+        pool_cfg = unknown_pool_cfg(filtered)
         pool_name = "Unknown"
 
     total_blocks = calc_total_port_blocks(pool_cfg)
@@ -600,9 +619,10 @@ def json_all(pba_entries, mappings, pools):
 
     pool_data = []
     for pool_name in sorted(pool_groups.keys()):
-        pool_cfg = pools.get(pool_name, {"block_size": 256, "client_block_limit": 1, "addresses": []})
+        entries = pool_groups[pool_name]
+        pool_cfg = pools.get(pool_name) or unknown_pool_cfg(entries)
         total_blocks = calc_total_port_blocks(pool_cfg)
-        pool_data.append(build_pool_data(pool_name, pool_cfg, pool_groups[pool_name], mappings, total_blocks))
+        pool_data.append(build_pool_data(pool_name, pool_cfg, entries, mappings, total_blocks))
 
     return {
         "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -704,7 +724,7 @@ def main():
             else:
                 pool_name, pool_cfg = find_pool_for_ip(args.xlated_ip, pools)
                 if not pool_cfg:
-                    pool_cfg = {"block_size": 256, "client_block_limit": 1, "addresses": []}
+                    pool_cfg = unknown_pool_cfg(filtered)
                     pool_name = "Unknown"
                 total_blocks = calc_total_port_blocks(pool_cfg)
                 print_pool_header(pool_name, pool_cfg, len(filtered), total_blocks,

--- a/python/install-pba-stats.sh
+++ b/python/install-pba-stats.sh
@@ -128,19 +128,28 @@ else
     while [ -n "$ENCODED" ]; do
         CHUNK="${ENCODED:0:$CHUNK_SIZE}"
         ENCODED="${ENCODED:$CHUNK_SIZE}"
-        run_ssh "echo '$CHUNK' >> $REMOTE_PATH.b64"
+        # Retry each chunk up to 3 times to handle transient connection failures
+        for attempt in 1 2 3; do
+            RESULT=$($SSH_CMD "$SSH_TARGET" "echo '$CHUNK' >> $REMOTE_PATH.b64 && echo OK" 2>&1 || true)
+            if echo "$RESULT" | grep -q "OK"; then
+                break
+            fi
+            sleep 1
+        done
     done
     run_ssh "base64 -d $REMOTE_PATH.b64 > $REMOTE_PATH && rm -f $REMOTE_PATH.b64"
 fi
 
-# Verify the file was copied
-REMOTE_LINES=$(run_ssh "wc -l < $REMOTE_PATH" | grep -o '[0-9]*' | head -1)
-LOCAL_LINES=$(wc -l < "$LOCAL_SCRIPT" | tr -d '[:space:]')
-if [ -z "$REMOTE_LINES" ] || [ "$REMOTE_LINES" -lt 10 ]; then
-    echo "ERROR: File copy verification failed (expected $LOCAL_LINES lines, got ${REMOTE_LINES:-0})"
+# Verify the file was copied using md5 checksum
+LOCAL_MD5=$(md5 -q "$LOCAL_SCRIPT" 2>/dev/null || md5sum "$LOCAL_SCRIPT" | awk '{print $1}')
+REMOTE_MD5=$(run_ssh "md5sum $REMOTE_PATH" | grep -oE '^[a-f0-9]{32}')
+if [ "$LOCAL_MD5" != "$REMOTE_MD5" ]; then
+    echo "ERROR: File copy verification failed (md5 mismatch)"
+    echo "    Local:  $LOCAL_MD5"
+    echo "    Remote: $REMOTE_MD5"
     exit 1
 fi
-echo "    Verified: $REMOTE_LINES lines"
+echo "    Verified: md5 $LOCAL_MD5"
 
 echo "==> Setting up ..."
 run_ssh "chmod +x $REMOTE_PATH"
@@ -158,16 +167,20 @@ echo "    Created $PROFILE"
 
 echo "==> Configuring startup persistence ..."
 # /etc/profile.d doesn't persist across BIG-IP upgrades; recreate it on boot
-STARTUP_CMD="echo '$PATH_LINE' > $PROFILE"
 STARTUP_CHECK=$(run_ssh "cat /config/startup 2>/dev/null || echo ''")
 if echo "$STARTUP_CHECK" | grep -qF "pba-stats"; then
     echo "    /config/startup already contains pba-stats entry"
 elif echo "$STARTUP_CHECK" | grep -q "#!/bin/bash"; then
-    run_ssh "echo '$STARTUP_CMD' >> /config/startup"
+    run_ssh "cat >> /config/startup << 'STARTUP_EOF'
+echo 'export PATH=$PATH_DIR:\$PATH' > $PROFILE
+STARTUP_EOF"
     echo "    Added PATH setup to /config/startup"
 else
-    run_ssh "printf '#!/bin/bash\n$STARTUP_CMD\n' > /config/startup"
-    run_ssh "chmod +x /config/startup"
+    run_ssh "cat > /config/startup << 'STARTUP_EOF'
+#!/bin/bash
+echo 'export PATH=$PATH_DIR:\$PATH' > $PROFILE
+STARTUP_EOF
+chmod +x /config/startup"
     echo "    Created /config/startup"
 fi
 


### PR DESCRIPTION
## Summary
- **SSH reconnection**: Properly close old connection, retry with 1-3s backoff to handle BIG-IP single-channel SSH limitation and connection rate-limiting
- **Remove fake defaults**: Stop hardcoding `block_size=256` / `client_block_limit=1` when pool config is unavailable; infer `block_size` from PBA entry port ranges, set `client_block_limit=0` for unknown pools
- **TMSH parsing**: Warn on stderr and skip pool if `block-size`/`client-block-limit` can't be parsed
- **Installer**: Add retry logic for base64 chunk transfer, md5 checksum verification, heredoc-based startup file creation

## Test plan
- [x] All pba-stats modes on BIG-IP (--all, --summary, --pool, --xlated-ip, --enhanced, --json)
- [x] All cgnat_pba_stats.py modes via SSH (--all, --summary, host lookup, --pool --enhanced, --json)
- [x] cgnat_pba_collect.py CSV output via SSH

🤖 Generated with [Claude Code](https://claude.com/claude-code)