### PR TITLE
v1.3.1 — CPU spike fix, port double-count fix, Pylance cleanup

### DIFF
--- a/python/cgnat_pba_collect.py
+++ b/python/cgnat_pba_collect.py
@@ -97,6 +97,7 @@ def ssh_command(cmd: str, timeout: int = 30) -> str:
     global SSH_CLIENT
     assert SSH_CLIENT is not None, "SSH connection not established"
     client = SSH_CLIENT
+    stdout = stderr = None
     try:
         _, stdout, stderr = client.exec_command(cmd, timeout=timeout)
     except paramiko.SSHException:
@@ -118,6 +119,7 @@ def ssh_command(cmd: str, timeout: int = 30) -> str:
                 last_err = e
         if last_err is not None:
             raise last_err
+    assert stdout is not None and stderr is not None
     output = stdout.read().decode() or stderr.read().decode() or ""
     lines = output.strip().split("\n")
     if len(lines) > 2:
@@ -223,7 +225,7 @@ def find_pool_for_ip(external_ip: str, pools: dict) -> str | None:
                     parts = addr_str.split("-")
                     start = ipaddress.ip_address(parts[0].strip())
                     end = ipaddress.ip_address(parts[1].strip())
-                    if start <= ext <= end:
+                    if int(start) <= int(ext) <= int(end):
                         return pool_name
                 elif "/" in addr_str:
                     net = ipaddress.ip_network(addr_str, strict=False)

--- a/python/cgnat_pba_collect.py
+++ b/python/cgnat_pba_collect.py
@@ -70,6 +70,7 @@ def _do_ssh_connect():
     """Internal: create and connect SSH client using stored params."""
     global SSH_CLIENT
     params = SSH_CONNECT_PARAMS
+    assert params is not None, "ssh_connect() must be called before _do_ssh_connect()"
     SSH_CLIENT = paramiko.SSHClient()
     if params["no_host_key_check"]:
         SSH_CLIENT.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -95,11 +96,12 @@ def ssh_command(cmd: str, timeout: int = 30) -> str:
     import time
     global SSH_CLIENT
     assert SSH_CLIENT is not None, "SSH connection not established"
+    client = SSH_CLIENT
     try:
-        _, stdout, stderr = SSH_CLIENT.exec_command(cmd, timeout=timeout)
+        _, stdout, stderr = client.exec_command(cmd, timeout=timeout)
     except paramiko.SSHException:
         try:
-            SSH_CLIENT.close()
+            client.close()
         except Exception:
             pass
         last_err = None
@@ -107,7 +109,9 @@ def ssh_command(cmd: str, timeout: int = 30) -> str:
             try:
                 time.sleep(1 + attempt)
                 _do_ssh_connect()
-                _, stdout, stderr = SSH_CLIENT.exec_command(cmd, timeout=timeout)
+                assert SSH_CLIENT is not None
+                client = SSH_CLIENT
+                _, stdout, stderr = client.exec_command(cmd, timeout=timeout)
                 last_err = None
                 break
             except Exception as e:
@@ -375,6 +379,7 @@ def export_mysql(rows: list[dict], timestamp: str, device: str,
         host=db_host, port=db_port, database=db_name,
         user=db_user, password=db_pass,
     )
+    cursor = None
     try:
         cursor = conn.cursor()
         cursor.execute(CREATE_TABLE_SQL.format(table=db_table))
@@ -392,7 +397,8 @@ def export_mysql(rows: list[dict], timestamp: str, device: str,
         conn.commit()
         print(f"Inserted {count} rows into {db_name}.{db_table}", file=sys.stderr)
     finally:
-        cursor.close()
+        if cursor is not None:
+            cursor.close()
         conn.close()
 
 # ---------------------------------------------------------------------------

--- a/python/cgnat_pba_stats.py
+++ b/python/cgnat_pba_stats.py
@@ -460,7 +460,7 @@ def print_pba_rows(entries: list[dict], mapping_index,
 
 
 def print_enhanced_host_footer(host_ip: str, entries: list[dict],
-                               client_mapping_index, pool_cfg: dict):
+                               mapping_index, pool_cfg: dict):
     """Print enhanced per-host summary footer."""
     block_size = pool_cfg["block_size"]
     max_blocks = pool_cfg["client_block_limit"]
@@ -469,14 +469,16 @@ def print_enhanced_host_footer(host_ip: str, entries: list[dict],
     total_capacity = num_blocks * block_size
     print()
     print(f"  --- Enhanced Host Summary for {host_ip} ---")
-    if client_mapping_index is not None:
+    if mapping_index is not None:
         total_ports = 0
         proto_totals: dict[str, int] = defaultdict(int)
         for entry in entries:
-            for m in client_mapping_index.get(host_ip, []):
-                if entry["external_ip"] == m["translation_ip"] and entry["port_start"] <= m["translation_port"] <= entry["port_end"]:
-                    total_ports += 1
+            ports_seen: set = set()
+            for m in mapping_index.get((host_ip, entry["external_ip"]), []):
+                if entry["port_start"] <= m["translation_port"] <= entry["port_end"]:
+                    ports_seen.add(m["translation_port"])
                     proto_totals[m.get("protocol", "?")] += 1
+            total_ports += len(ports_seen)
         util_pct = (total_ports / total_capacity * 100) if total_capacity > 0 else 0
         print(f"  Total ports in use:    {total_ports:>6}  /  {total_capacity} capacity")
         print(f"  Overall utilization:   {util_pct:>5.1f}%")
@@ -484,14 +486,14 @@ def print_enhanced_host_footer(host_ip: str, entries: list[dict],
         print("  Port utilization:      (unavailable with --no-inbound)")
     print(f"  Blocks allocated:      {num_blocks:>6}  /  {max_blocks} max")
     print(f"  Blocks remaining:      {max(0, max_blocks - num_blocks):>6}")
-    if client_mapping_index is not None and proto_totals:
+    if mapping_index is not None and proto_totals:
         proto_str = "  ".join(f"{proto}: {cnt}" for proto, cnt in sorted(proto_totals.items()))
         print(f"  Protocol totals:       {proto_str}")
     ext_ips = sorted(set(e["external_ip"] for e in entries))
     print(f"  External IPs:          {', '.join(ext_ips)}")
 
 
-def print_enhanced_pool_footer(entries: list[dict], client_mapping_index,
+def print_enhanced_pool_footer(entries: list[dict], mapping_index,
                                pool_cfg: dict, pool_name: str, total_blocks: int, top_n: int = 10):
     """Print enhanced per-pool summary footer with top subscribers and IP distribution."""
     block_size = pool_cfg["block_size"]
@@ -503,10 +505,11 @@ def print_enhanced_pool_footer(entries: list[dict], client_mapping_index,
             client_stats[cip] = {"blocks": 0, "ports": 0, "external_ips": set()}
         client_stats[cip]["blocks"] += 1
         client_stats[cip]["external_ips"].add(entry["external_ip"])
-        if client_mapping_index is not None:
-            for m in client_mapping_index.get(cip, []):
-                if entry["external_ip"] == m["translation_ip"] and entry["port_start"] <= m["translation_port"] <= entry["port_end"]:
-                    client_stats[cip]["ports"] += 1
+        if mapping_index is not None:
+            n = count_ports_used(
+                cip, entry["external_ip"], entry["port_start"], entry["port_end"], mapping_index
+            )
+            client_stats[cip]["ports"] += n
 
     unique_clients = len(client_stats)
     total_blocks_used = len(entries)
@@ -518,13 +521,13 @@ def print_enhanced_pool_footer(entries: list[dict], client_mapping_index,
     print(f"  --- Enhanced Pool Summary: {pool_name} ---")
     print(f"  Unique clients:        {unique_clients:>6}")
     print(f"  Total blocks used:     {total_blocks_used:>6}  /  {total_blocks} total  ({pool_util_pct:.1f}%)")
-    if client_mapping_index is not None:
+    if mapping_index is not None:
         total_ports = sum(s["ports"] for s in client_stats.values())
         util_pct = (total_ports / total_capacity * 100) if total_capacity > 0 else 0
         print(f"  Total ports in use:    {total_ports:>6}  /  {total_capacity} capacity  ({util_pct:.1f}%)")
     print(f"  Avg blocks per client: {avg_blocks:>6.1f}")
 
-    if client_mapping_index is not None:
+    if mapping_index is not None:
         top_by_ports = sorted(client_stats.items(), key=lambda x: x[1]["ports"], reverse=True)[:top_n]
         print(f"\n  Top {min(top_n, len(top_by_ports))} subscribers by port usage:")
         print(f"    {'Client_IP':<20} {'Ports':>8} {'Blocks':>8} {'Util%':>8}  {'External_IPs'}")
@@ -539,7 +542,7 @@ def print_enhanced_pool_footer(entries: list[dict], client_mapping_index,
     print(f"    {'Client_IP':<20} {'Blocks':>8} {'Ports':>8} {'Util%':>8}")
     for cip, stats in top_by_blocks:
         cap = stats["blocks"] * block_size
-        if client_mapping_index is not None:
+        if mapping_index is not None:
             u = (stats["ports"] / cap * 100) if cap > 0 else 0
             print(f"    {cip:<20} {stats['blocks']:>8} {stats['ports']:>8} {u:>7.1f}%")
         else:
@@ -575,7 +578,7 @@ def show_host(host_ip: str, pba_entries: list[dict], mapping_index: dict[tuple[s
                       enhanced=enhanced)
     print_pba_rows(host_entries, mapping_index, pool_cfg["block_size"], enhanced=enhanced)
     if enhanced:
-        print_enhanced_host_footer(host_ip, host_entries, client_mapping_index, pool_cfg)
+        print_enhanced_host_footer(host_ip, host_entries, mapping_index, pool_cfg)
 
 
 def show_pool(pool_name: str, pba_entries: list[dict], mapping_index: dict[tuple[str, str], list[dict]],
@@ -598,7 +601,7 @@ def show_pool(pool_name: str, pba_entries: list[dict], mapping_index: dict[tuple
     print_pool_header(pool_name, pool_cfg, len(pool_entries), total_blocks, enhanced=enhanced)
     print_pba_rows(pool_entries, mapping_index, pool_cfg["block_size"], enhanced=enhanced)
     if enhanced:
-        print_enhanced_pool_footer(pool_entries, client_mapping_index, pool_cfg, pool_name, total_blocks)
+        print_enhanced_pool_footer(pool_entries, mapping_index, pool_cfg, pool_name, total_blocks)
 
 
 def show_all(pba_entries: list[dict], mapping_index: dict[tuple[str, str], list[dict]],
@@ -622,7 +625,7 @@ def show_all(pba_entries: list[dict], mapping_index: dict[tuple[str, str], list[
         print_pool_header(pool_name, pool_cfg, len(entries), total_blocks, enhanced=enhanced)
         print_pba_rows(entries, mapping_index, pool_cfg["block_size"], enhanced=enhanced)
         if enhanced:
-            print_enhanced_pool_footer(entries, client_mapping_index, pool_cfg, pool_name, total_blocks)
+            print_enhanced_pool_footer(entries, mapping_index, pool_cfg, pool_name, total_blocks)
 
 
 def show_summary(pba_entries: list[dict], pools: dict, enhanced: bool = False):
@@ -1130,7 +1133,7 @@ def main():
                                       enhanced=enhanced)
                     print_pba_rows(filtered, mapping_index, pool_cfg["block_size"], enhanced=enhanced)
                     if enhanced:
-                        print_enhanced_pool_footer(filtered, client_mapping_index, pool_cfg, pool_name,
+                        print_enhanced_pool_footer(filtered, mapping_index, pool_cfg, pool_name,
                                                    total_blocks)
             elif args.all:
                 show_all(pba_entries, mapping_index, client_mapping_index, pools, enhanced=enhanced)

--- a/python/cgnat_pba_stats_bigip_compatible.py
+++ b/python/cgnat_pba_stats_bigip_compatible.py
@@ -193,10 +193,13 @@ def get_pba_client_summary():
 
 def _collect_parallel(want_inbound):
     """
-    Collect pool configs, PBA entries, and optionally inbound mappings concurrently.
+    Collect pool configs, PBA entries, and optionally inbound mappings.
+    tmsh and lsndb list pba run concurrently (different subsystems); lsndb list
+    inbound runs sequentially after to avoid two concurrent lsndb queries on lsnd,
+    which is the primary cause of CPU spikes on busy deployments.
     Returns (pools, pba_entries, mappings).
     """
-    results = {"pools": {}, "pba": [], "mappings": []}
+    results = {"pools": {}, "pba": []}
 
     def _get_pools():
         results["pools"] = get_pool_configs()
@@ -204,22 +207,17 @@ def _collect_parallel(want_inbound):
     def _get_pba():
         results["pba"] = get_pba_entries()
 
-    def _get_inbound():
-        results["mappings"] = get_inbound_mappings()
-
     threads = [
         threading.Thread(target=_get_pools),
         threading.Thread(target=_get_pba),
     ]
-    if want_inbound:
-        threads.append(threading.Thread(target=_get_inbound))
-
     for t in threads:
         t.start()
     for t in threads:
         t.join()
 
-    return results["pools"], results["pba"], results["mappings"]
+    mappings = get_inbound_mappings() if want_inbound else []
+    return results["pools"], results["pba"], mappings
 
 
 # ---------------------------------------------------------------------------
@@ -396,7 +394,7 @@ def print_pba_rows(entries, mapping_index, block_size, enhanced=False):
         print(line)
 
 
-def print_enhanced_host_footer(host_ip, entries, client_mapping_index, pool_cfg):
+def print_enhanced_host_footer(host_ip, entries, mapping_index, pool_cfg):
     block_size = pool_cfg["block_size"]
     max_blocks = pool_cfg["client_block_limit"]
     num_blocks = len(entries)
@@ -404,14 +402,16 @@ def print_enhanced_host_footer(host_ip, entries, client_mapping_index, pool_cfg)
     total_capacity = num_blocks * block_size
     print()
     print("  --- Enhanced Host Summary for %s ---" % host_ip)
-    if client_mapping_index is not None:
+    if mapping_index is not None:
         total_ports = 0
         proto_totals = defaultdict(int)
         for entry in entries:
-            for m in client_mapping_index.get(host_ip, []):
+            ports_seen = set()
+            for m in mapping_index.get((host_ip, entry["external_ip"]), []):
                 if entry["port_start"] <= m["translation_port"] <= entry["port_end"]:
-                    total_ports += 1
+                    ports_seen.add(m["translation_port"])
                     proto_totals[m.get("protocol", "?")] += 1
+            total_ports += len(ports_seen)
         util_pct = (total_ports / total_capacity * 100) if total_capacity > 0 else 0
         print("  Total ports in use:    %6d  /  %d capacity" % (total_ports, total_capacity))
         print("  Overall utilization:   %5.1f%%" % util_pct)
@@ -419,14 +419,14 @@ def print_enhanced_host_footer(host_ip, entries, client_mapping_index, pool_cfg)
         print("  Port utilization:      (unavailable with --no-inbound)")
     print("  Blocks allocated:      %6d  /  %d max" % (num_blocks, max_blocks))
     print("  Blocks remaining:      %6d" % max(0, max_blocks - num_blocks))
-    if client_mapping_index is not None and proto_totals:
+    if mapping_index is not None and proto_totals:
         proto_str = "  ".join("%s: %d" % (proto, cnt) for proto, cnt in sorted(proto_totals.items()))
         print("  Protocol totals:       %s" % proto_str)
     ext_ips = sorted(set(e["external_ip"] for e in entries))
     print("  External IPs:          %s" % ", ".join(ext_ips))
 
 
-def print_enhanced_pool_footer(entries, client_mapping_index, pool_cfg, pool_name, total_blocks,
+def print_enhanced_pool_footer(entries, mapping_index, pool_cfg, pool_name, total_blocks,
                                top_n=10):
     block_size = pool_cfg["block_size"]
 
@@ -437,10 +437,9 @@ def print_enhanced_pool_footer(entries, client_mapping_index, pool_cfg, pool_nam
             client_stats[cip] = {"blocks": 0, "ports": 0, "external_ips": set()}
         client_stats[cip]["blocks"] += 1
         client_stats[cip]["external_ips"].add(entry["external_ip"])
-        if client_mapping_index is not None:
-            for m in client_mapping_index.get(cip, []):
-                if entry["port_start"] <= m["translation_port"] <= entry["port_end"]:
-                    client_stats[cip]["ports"] += 1
+        if mapping_index is not None:
+            n = count_ports_used(cip, entry["external_ip"], entry["port_start"], entry["port_end"], mapping_index)
+            client_stats[cip]["ports"] += n
 
     unique_clients = len(client_stats)
     total_blocks_used = len(entries)
@@ -453,14 +452,14 @@ def print_enhanced_pool_footer(entries, client_mapping_index, pool_cfg, pool_nam
     print("  Unique clients:        %6d" % unique_clients)
     print("  Total blocks used:     %6d  /  %d total  (%.1f%%)" % (
         total_blocks_used, total_blocks, pool_util_pct))
-    if client_mapping_index is not None:
+    if mapping_index is not None:
         total_ports = sum(s["ports"] for s in client_stats.values())
         util_pct = (total_ports / total_capacity * 100) if total_capacity > 0 else 0
         print("  Total ports in use:    %6d  /  %d capacity  (%.1f%%)" % (
             total_ports, total_capacity, util_pct))
     print("  Avg blocks per client: %6.1f" % avg_blocks)
 
-    if client_mapping_index is not None:
+    if mapping_index is not None:
         top_by_ports = sorted(client_stats.items(), key=lambda x: x[1]["ports"], reverse=True)[:top_n]
         print()
         print("  Top %d subscribers by port usage:" % min(top_n, len(top_by_ports)))
@@ -477,7 +476,7 @@ def print_enhanced_pool_footer(entries, client_mapping_index, pool_cfg, pool_nam
     print("    %-20s %8s %8s %8s" % ("Client_IP", "Blocks", "Ports", "Util%"))
     for cip, stats in top_by_blocks:
         cap = stats["blocks"] * block_size
-        if client_mapping_index is not None:
+        if mapping_index is not None:
             u = (stats["ports"] / cap * 100) if cap > 0 else 0
             print("    %-20s %8d %8d %7.1f%%" % (cip, stats["blocks"], stats["ports"], u))
         else:
@@ -509,7 +508,7 @@ def show_host(host_ip, pba_entries, mapping_index, client_mapping_index, pools, 
                       enhanced=enhanced)
     print_pba_rows(host_entries, mapping_index, pool_cfg["block_size"], enhanced=enhanced)
     if enhanced:
-        print_enhanced_host_footer(host_ip, host_entries, client_mapping_index, pool_cfg)
+        print_enhanced_host_footer(host_ip, host_entries, mapping_index, pool_cfg)
 
 
 def show_pool(pool_name, pba_entries, mapping_index, client_mapping_index, pools, enhanced=False):
@@ -531,7 +530,7 @@ def show_pool(pool_name, pba_entries, mapping_index, client_mapping_index, pools
     print_pool_header(pool_name, pool_cfg, len(pool_entries), total_blocks, enhanced=enhanced)
     print_pba_rows(pool_entries, mapping_index, pool_cfg["block_size"], enhanced=enhanced)
     if enhanced:
-        print_enhanced_pool_footer(pool_entries, client_mapping_index, pool_cfg, pool_name, total_blocks)
+        print_enhanced_pool_footer(pool_entries, mapping_index, pool_cfg, pool_name, total_blocks)
 
 
 def show_all(pba_entries, mapping_index, client_mapping_index, pools, enhanced=False):
@@ -550,7 +549,7 @@ def show_all(pba_entries, mapping_index, client_mapping_index, pools, enhanced=F
         print_pool_header(pool_name, pool_cfg, len(entries), total_blocks, enhanced=enhanced)
         print_pba_rows(entries, mapping_index, pool_cfg["block_size"], enhanced=enhanced)
         if enhanced:
-            print_enhanced_pool_footer(entries, client_mapping_index, pool_cfg, pool_name, total_blocks)
+            print_enhanced_pool_footer(entries, mapping_index, pool_cfg, pool_name, total_blocks)
 
 
 def show_summary(pba_entries, pools, enhanced=False):
@@ -1014,7 +1013,7 @@ def main():
                               enhanced=enhanced)
             print_pba_rows(filtered, mapping_index, pool_cfg["block_size"], enhanced=enhanced)
             if enhanced:
-                print_enhanced_pool_footer(filtered, client_mapping_index, pool_cfg, pool_name,
+                print_enhanced_pool_footer(filtered, mapping_index, pool_cfg, pool_name,
                                            total_blocks)
     elif args.all:
         show_all(pba_entries, mapping_index, client_mapping_index, pools, enhanced=enhanced)


### PR DESCRIPTION
## Summary

- **CPU spike fix**: `_collect_parallel` now runs `lsndb list inbound` sequentially after `lsndb list pba` instead of concurrently. Both commands contend for lsnd's TMM shared-memory lock; concurrent execution drives CPU to 100% on loaded deployments.
- **Port double-count fix**: `print_enhanced_pool_footer` / `print_enhanced_host_footer` now use `mapping_index` lookups and `count_ports_used` (set-based unique port counting) instead of the previous O(blocks × all-client-mappings) inner loop. Fixes inflated port counts in `--enhanced` mode footers and aligns with the invariant documented in CLAUDE.md.
- **Pylance cleanup**: resolved all remaining type warnings in `cgnat_pba_collect.py`.

## Test plan

- [ ] Run `--enhanced --pool <name>` on a live device; confirm footer port counts match per-row output
- [ ] Run collector in `--enhanced` mode on a busy device; confirm no CPU spike during collection window
- [ ] Verify `--all`, `--summary`, and `--json` output schema unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)