### PR TITLE
Refuse SHA-1 RSA signatures in SSH connections (CVE-2026-44405)

### DIFF
--- a/python/cgnat_api_stats.py
+++ b/python/cgnat_api_stats.py
@@ -66,7 +66,12 @@ def _do_ssh_connect():
     SSH_CLIENT = paramiko.SSHClient()
     if params["no_host_key_check"]:
         SSH_CLIENT.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    SSH_CLIENT.connect(**{k: v for k, v in params.items() if k != "no_host_key_check"})
+    # Refuse SHA-1 RSA signatures (CVE-2026-44405); rsa-sha2-256/512 and
+    # non-RSA keys still negotiate. TMOS 17.x sshd supports rsa-sha2.
+    SSH_CLIENT.connect(
+        disabled_algorithms={"pubkeys": ["ssh-rsa"], "keys": ["ssh-rsa"]},
+        **{k: v for k, v in params.items() if k != "no_host_key_check"},
+    )
 
 
 def api_get(endpoint: str) -> Dict[str, Any]:

--- a/python/cgnat_pba_collect.py
+++ b/python/cgnat_pba_collect.py
@@ -83,6 +83,9 @@ def _do_ssh_connect():
         key_filename=params["key_filename"], timeout=params["timeout"],
         allow_agent=params["allow_agent"],
         look_for_keys=params["look_for_keys"],
+        # Refuse SHA-1 RSA signatures (CVE-2026-44405); rsa-sha2-256/512 and
+        # non-RSA keys still negotiate. TMOS 17.x sshd supports rsa-sha2.
+        disabled_algorithms={"pubkeys": ["ssh-rsa"], "keys": ["ssh-rsa"]},
     )
 
 

--- a/python/cgnat_pba_stats.py
+++ b/python/cgnat_pba_stats.py
@@ -79,6 +79,9 @@ def _do_ssh_connect():
         key_filename=params["key_filename"], timeout=params["timeout"],
         allow_agent=params["allow_agent"],
         look_for_keys=params["look_for_keys"],
+        # Refuse SHA-1 RSA signatures (CVE-2026-44405); rsa-sha2-256/512 and
+        # non-RSA keys still negotiate. TMOS 17.x sshd supports rsa-sha2.
+        disabled_algorithms={"pubkeys": ["ssh-rsa"], "keys": ["ssh-rsa"]},
     )
 
 


### PR DESCRIPTION
Paramiko <= 4.0.0 accepts SHA-1 ssh-rsa signatures (GHSA-r374-rxx8-8654) and no patched release exists yet. Pass disabled_algorithms to SSHClient.connect() in all three remote scripts so SHA-1 RSA is never negotiated for host key or auth signatures; rsa-sha2-256/512 and non-RSA keys are unaffected. TMOS 17.x sshd supports rsa-sha2.